### PR TITLE
Add ServiceNow Case Management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,13 @@ The default `config/tool_packages.yaml` includes the following role-based packag
 4. **resolve_incident** - Resolve an incident in ServiceNow
 5. **list_incidents** - List incidents from ServiceNow
 
+#### Case Management Tools
+
+1. **create_case** - Create a new customer service case in ServiceNow
+2. **update_case** - Update an existing customer service case in ServiceNow
+3. **list_cases** - List customer service cases from ServiceNow
+4. **get_case** - Get details about a specific customer service case
+
 #### Service Catalog Tools
 
 1. **list_catalog_items** - List service catalog items from ServiceNow
@@ -308,6 +315,12 @@ Below are some example natural language queries you can use with Claude to inter
 - "Resolve incident INC0010001 with a note that the server was restarted"
 - "List all high priority incidents assigned to the Network team"
 - "List all active P1 incidents assigned to the Network team."
+
+#### Case Management Examples
+- "Create a new customer case for a billing issue"
+- "Update case CASE0012345 to set the priority to high"
+- "Show me details for case CASE0012345"
+- "List all open cases for account ACME"
 
 #### Service Catalog Examples
 - "Show me all items in the service catalog"
@@ -448,6 +461,7 @@ Additional documentation is available in the `docs` directory:
 - [Change Management](docs/change_management.md) - Detailed information about the Change Management tools
 - [Workflow Management](docs/workflow_management.md) - Detailed information about the Workflow Management tools
 - [Changeset Management](docs/changeset_management.md) - Detailed information about the Changeset Management tools
+- [Case Management](docs/case_management.md) - Detailed information about customer service case tools
 
 ### Troubleshooting
 

--- a/config/tool_packages.yaml
+++ b/config/tool_packages.yaml
@@ -15,6 +15,11 @@ service_desk:
   - add_comment
   - resolve_incident
   - list_incidents
+  # Case Management
+  - create_case
+  - update_case
+  - list_cases
+  - get_case
   # User Lookup
   - get_user
   - list_users
@@ -131,6 +136,11 @@ full:
   - add_comment
   - resolve_incident
   - list_incidents
+  # Case Management
+  - create_case
+  - update_case
+  - list_cases
+  - get_case
   # Catalog (Core)
   - list_catalogs
   - list_catalog_items

--- a/docs/case_management.md
+++ b/docs/case_management.md
@@ -1,0 +1,101 @@
+# Case Management
+
+This document describes the case management functionality provided by the ServiceNow MCP server.
+
+## Overview
+
+The case management module allows LLMs to interact with ServiceNow Customer Service cases through the Model Context Protocol (MCP). It provides resources for querying case data and tools for creating and updating cases.
+
+## Resources
+
+### List Cases
+
+Retrieves a list of cases from ServiceNow.
+
+**Resource Name:** `cases`
+
+**Parameters:**
+- `limit` (int, default: 10): Maximum number of cases to return
+- `offset` (int, default: 0): Offset for pagination
+- `state` (string, optional): Filter by case state
+- `priority` (string, optional): Filter by case priority
+- `query` (string, optional): Search query for cases
+
+**Example:**
+```python
+cases = await mcp.get_resource("servicenow", "cases", {
+    "limit": 5,
+    "state": "open",
+})
+for case in cases:
+    print(f"{case['number']}: {case['short_description']}")
+```
+
+### Get Case
+
+Retrieves a specific case from ServiceNow by ID or number.
+
+**Resource Name:** `case`
+
+**Parameters:**
+- `case_id` (string): Case ID or sys_id
+
+**Example:**
+```python
+case = await mcp.get_resource("servicenow", "case", {"case_id": "CASE0012345"})
+print(case)
+```
+
+## Tools
+
+### Create Case
+
+Creates a new case in ServiceNow.
+
+**Tool Name:** `create_case`
+
+**Parameters:**
+- `short_description` (string, required): Short description of the case
+- `description` (string, optional): Detailed description of the case
+- `contact` (string, optional): Contact associated with the case
+- `account` (string, optional): Account associated with the case
+- `priority` (string, optional): Priority of the case
+- `state` (string, optional): State of the case
+- `assigned_to` (string, optional): User assigned to the case
+- `assignment_group` (string, optional): Group assigned to the case
+
+### Update Case
+
+Updates an existing case in ServiceNow.
+
+**Tool Name:** `update_case`
+
+**Parameters:**
+- `case_id` (string, required): Case ID or sys_id
+- `short_description` (string, optional): Short description of the case
+- `description` (string, optional): Detailed description of the case
+- `contact` (string, optional): Contact associated with the case
+- `account` (string, optional): Account associated with the case
+- `priority` (string, optional): Priority of the case
+- `state` (string, optional): State of the case
+- `assigned_to` (string, optional): User assigned to the case
+- `assignment_group` (string, optional): Group assigned to the case
+
+### List Cases
+
+Lists customer service cases.
+
+**Tool Name:** `list_cases`
+
+Uses the same parameters as the `cases` resource.
+
+### Get Case
+
+Gets details for a specific case.
+
+**Tool Name:** `get_case`
+
+**Parameters:**
+- `case_id` (string, required): Case ID or sys_id
+
+

--- a/src/servicenow_mcp/tools/__init__.py
+++ b/src/servicenow_mcp/tools/__init__.py
@@ -46,6 +46,12 @@ from servicenow_mcp.tools.incident_tools import (
     resolve_incident,
     update_incident,
 )
+from servicenow_mcp.tools.case_tools import (
+    create_case,
+    update_case,
+    list_cases,
+    get_case,
+)
 from servicenow_mcp.tools.knowledge_base import (
     create_article,
     create_category,
@@ -100,6 +106,11 @@ __all__ = [
     "add_comment",
     "resolve_incident",
     "list_incidents",
+    # Case tools
+    "create_case",
+    "update_case",
+    "list_cases",
+    "get_case",
     
     # Catalog tools
     "list_catalog_items",

--- a/src/servicenow_mcp/tools/case_tools.py
+++ b/src/servicenow_mcp/tools/case_tools.py
@@ -1,0 +1,286 @@
+"""Case management tools for the ServiceNow MCP server."""
+
+import logging
+from typing import Optional, Dict, Any
+
+import requests
+from pydantic import BaseModel, Field
+
+from servicenow_mcp.auth.auth_manager import AuthManager
+from servicenow_mcp.utils.config import ServerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class CreateCaseParams(BaseModel):
+    """Parameters for creating a case."""
+
+    short_description: str = Field(..., description="Short description of the case")
+    description: Optional[str] = Field(None, description="Detailed description of the case")
+    contact: Optional[str] = Field(None, description="Contact associated with the case")
+    account: Optional[str] = Field(None, description="Account associated with the case")
+    priority: Optional[str] = Field(None, description="Priority of the case")
+    state: Optional[str] = Field(None, description="State of the case")
+    assigned_to: Optional[str] = Field(None, description="User assigned to the case")
+    assignment_group: Optional[str] = Field(None, description="Group assigned to the case")
+
+
+class UpdateCaseParams(BaseModel):
+    """Parameters for updating a case."""
+
+    case_id: str = Field(..., description="Case ID or sys_id")
+    short_description: Optional[str] = Field(None, description="Short description of the case")
+    description: Optional[str] = Field(None, description="Detailed description of the case")
+    contact: Optional[str] = Field(None, description="Contact associated with the case")
+    account: Optional[str] = Field(None, description="Account associated with the case")
+    priority: Optional[str] = Field(None, description="Priority of the case")
+    state: Optional[str] = Field(None, description="State of the case")
+    assigned_to: Optional[str] = Field(None, description="User assigned to the case")
+    assignment_group: Optional[str] = Field(None, description="Group assigned to the case")
+
+
+class ListCasesParams(BaseModel):
+    """Parameters for listing cases."""
+
+    limit: int = Field(10, description="Maximum number of cases to return")
+    offset: int = Field(0, description="Offset for pagination")
+    state: Optional[str] = Field(None, description="Filter by case state")
+    priority: Optional[str] = Field(None, description="Filter by case priority")
+    query: Optional[str] = Field(None, description="Search query for cases")
+
+
+class GetCaseParams(BaseModel):
+    """Parameters for getting a case."""
+
+    case_id: str = Field(..., description="Case ID or sys_id")
+
+
+class CaseResponse(BaseModel):
+    """Response from case operations."""
+
+    success: bool = Field(..., description="Whether the operation was successful")
+    message: str = Field(..., description="Message describing the result")
+    case_id: Optional[str] = Field(None, description="ID of the affected case")
+    case_number: Optional[str] = Field(None, description="Number of the affected case")
+
+
+def create_case(config: ServerConfig, auth_manager: AuthManager, params: CreateCaseParams) -> CaseResponse:
+    """Create a new case in ServiceNow."""
+    api_url = f"{config.api_url}/table/sn_customerservice_case"
+    data = {
+        "short_description": params.short_description,
+    }
+    if params.description:
+        data["description"] = params.description
+    if params.contact:
+        data["contact"] = params.contact
+    if params.account:
+        data["account"] = params.account
+    if params.priority:
+        data["priority"] = params.priority
+    if params.state:
+        data["state"] = params.state
+    if params.assigned_to:
+        data["assigned_to"] = params.assigned_to
+    if params.assignment_group:
+        data["assignment_group"] = params.assignment_group
+
+    try:
+        response = requests.post(
+            api_url,
+            json=data,
+            headers=auth_manager.get_headers(),
+            timeout=config.timeout,
+        )
+        response.raise_for_status()
+        result = response.json().get("result", {})
+        return CaseResponse(
+            success=True,
+            message="Case created successfully",
+            case_id=result.get("sys_id"),
+            case_number=result.get("number"),
+        )
+    except requests.RequestException as e:
+        logger.error(f"Failed to create case: {e}")
+        return CaseResponse(success=False, message=f"Failed to create case: {str(e)}")
+
+
+def update_case(config: ServerConfig, auth_manager: AuthManager, params: UpdateCaseParams) -> CaseResponse:
+    """Update an existing case in ServiceNow."""
+    case_id = params.case_id
+    if len(case_id) == 32 and all(c in "0123456789abcdef" for c in case_id):
+        api_url = f"{config.api_url}/table/sn_customerservice_case/{case_id}"
+    else:
+        try:
+            query_url = f"{config.api_url}/table/sn_customerservice_case"
+            query_params = {
+                "sysparm_query": f"number={case_id}",
+                "sysparm_limit": 1,
+            }
+            response = requests.get(
+                query_url,
+                params=query_params,
+                headers=auth_manager.get_headers(),
+                timeout=config.timeout,
+            )
+            response.raise_for_status()
+            result = response.json().get("result", [])
+            if not result:
+                return CaseResponse(success=False, message=f"Case not found: {case_id}")
+            case_id = result[0].get("sys_id")
+            api_url = f"{config.api_url}/table/sn_customerservice_case/{case_id}"
+        except requests.RequestException as e:
+            logger.error(f"Failed to find case: {e}")
+            return CaseResponse(success=False, message=f"Failed to find case: {str(e)}")
+
+    data: Dict[str, Any] = {}
+    if params.short_description:
+        data["short_description"] = params.short_description
+    if params.description:
+        data["description"] = params.description
+    if params.contact:
+        data["contact"] = params.contact
+    if params.account:
+        data["account"] = params.account
+    if params.priority:
+        data["priority"] = params.priority
+    if params.state:
+        data["state"] = params.state
+    if params.assigned_to:
+        data["assigned_to"] = params.assigned_to
+    if params.assignment_group:
+        data["assignment_group"] = params.assignment_group
+
+    try:
+        response = requests.put(
+            api_url,
+            json=data,
+            headers=auth_manager.get_headers(),
+            timeout=config.timeout,
+        )
+        response.raise_for_status()
+        result = response.json().get("result", {})
+        return CaseResponse(
+            success=True,
+            message="Case updated successfully",
+            case_id=result.get("sys_id"),
+            case_number=result.get("number"),
+        )
+    except requests.RequestException as e:
+        logger.error(f"Failed to update case: {e}")
+        return CaseResponse(success=False, message=f"Failed to update case: {str(e)}")
+
+
+def list_cases(config: ServerConfig, auth_manager: AuthManager, params: ListCasesParams) -> Dict[str, Any]:
+    """List cases from ServiceNow."""
+    api_url = f"{config.api_url}/table/sn_customerservice_case"
+    query_params = {
+        "sysparm_limit": params.limit,
+        "sysparm_offset": params.offset,
+        "sysparm_display_value": "true",
+        "sysparm_exclude_reference_link": "true",
+    }
+    filters = []
+    if params.state:
+        filters.append(f"state={params.state}")
+    if params.priority:
+        filters.append(f"priority={params.priority}")
+    if params.query:
+        filters.append(f"short_descriptionLIKE{params.query}^ORdescriptionLIKE{params.query}")
+    if filters:
+        query_params["sysparm_query"] = "^".join(filters)
+
+    try:
+        response = requests.get(
+            api_url,
+            params=query_params,
+            headers=auth_manager.get_headers(),
+            timeout=config.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        cases = []
+        for case_data in data.get("result", []):
+            assigned_to = case_data.get("assigned_to")
+            if isinstance(assigned_to, dict):
+                assigned_to = assigned_to.get("display_value")
+            cases.append({
+                "sys_id": case_data.get("sys_id"),
+                "number": case_data.get("number"),
+                "short_description": case_data.get("short_description"),
+                "description": case_data.get("description"),
+                "state": case_data.get("state"),
+                "priority": case_data.get("priority"),
+                "assigned_to": assigned_to,
+                "created_on": case_data.get("sys_created_on"),
+                "updated_on": case_data.get("sys_updated_on"),
+            })
+        return {
+            "success": True,
+            "message": f"Found {len(cases)} cases",
+            "cases": cases,
+        }
+    except requests.RequestException as e:
+        logger.error(f"Failed to list cases: {e}")
+        return {"success": False, "message": f"Failed to list cases: {str(e)}", "cases": []}
+
+
+def get_case(config: ServerConfig, auth_manager: AuthManager, params: GetCaseParams) -> Dict[str, Any]:
+    """Get a specific case by ID or number."""
+    case_id = params.case_id
+    if len(case_id) == 32 and all(c in "0123456789abcdef" for c in case_id):
+        api_url = f"{config.api_url}/table/sn_customerservice_case/{case_id}"
+    else:
+        query_url = f"{config.api_url}/table/sn_customerservice_case"
+        query_params = {
+            "sysparm_query": f"number={case_id}",
+            "sysparm_limit": 1,
+            "sysparm_display_value": "true",
+            "sysparm_exclude_reference_link": "true",
+        }
+        try:
+            response = requests.get(
+                query_url,
+                params=query_params,
+                headers=auth_manager.get_headers(),
+                timeout=config.timeout,
+            )
+            response.raise_for_status()
+            result = response.json().get("result", [])
+            if not result:
+                return {"success": False, "message": f"Case not found: {case_id}"}
+            case_id = result[0].get("sys_id")
+            api_url = f"{config.api_url}/table/sn_customerservice_case/{case_id}"
+        except requests.RequestException as e:
+            logger.error(f"Failed to find case: {e}")
+            return {"success": False, "message": f"Failed to find case: {str(e)}"}
+
+    try:
+        response = requests.get(
+            api_url,
+            headers=auth_manager.get_headers(),
+            timeout=config.timeout,
+        )
+        response.raise_for_status()
+        result = response.json().get("result", {})
+        if not result:
+            return {"success": False, "message": f"Case not found: {case_id}"}
+        assigned_to = result.get("assigned_to")
+        if isinstance(assigned_to, dict):
+            assigned_to = assigned_to.get("display_value")
+        case_data = {
+            "sys_id": result.get("sys_id"),
+            "number": result.get("number"),
+            "short_description": result.get("short_description"),
+            "description": result.get("description"),
+            "state": result.get("state"),
+            "priority": result.get("priority"),
+            "assigned_to": assigned_to,
+            "created_on": result.get("sys_created_on"),
+            "updated_on": result.get("sys_updated_on"),
+        }
+        return {"success": True, "case": case_data}
+    except requests.RequestException as e:
+        logger.error(f"Failed to get case: {e}")
+        return {"success": False, "message": f"Failed to get case: {str(e)}"}
+

--- a/src/servicenow_mcp/utils/tool_utils.py
+++ b/src/servicenow_mcp/utils/tool_utils.py
@@ -138,6 +138,24 @@ from servicenow_mcp.tools.incident_tools import (
 from servicenow_mcp.tools.incident_tools import (
     update_incident as update_incident_tool,
 )
+from servicenow_mcp.tools.case_tools import (
+    CreateCaseParams,
+    UpdateCaseParams,
+    ListCasesParams,
+    GetCaseParams,
+)
+from servicenow_mcp.tools.case_tools import (
+    create_case as create_case_tool,
+)
+from servicenow_mcp.tools.case_tools import (
+    update_case as update_case_tool,
+)
+from servicenow_mcp.tools.case_tools import (
+    list_cases as list_cases_tool,
+)
+from servicenow_mcp.tools.case_tools import (
+    get_case as get_case_tool,
+)
 from servicenow_mcp.tools.knowledge_base import (
     CreateArticleParams,
     CreateKnowledgeBaseParams,
@@ -349,6 +367,35 @@ def get_tool_definitions(
             str,  # Expects JSON string
             "List incidents from ServiceNow",
             "json",  # Tool returns list/dict, needs JSON dump
+        ),
+        # Case Tools
+        "create_case": (
+            create_case_tool,
+            CreateCaseParams,
+            str,
+            "Create a new customer service case in ServiceNow",
+            "str",
+        ),
+        "update_case": (
+            update_case_tool,
+            UpdateCaseParams,
+            str,
+            "Update an existing customer service case in ServiceNow",
+            "str",
+        ),
+        "list_cases": (
+            list_cases_tool,
+            ListCasesParams,
+            str,
+            "List customer service cases from ServiceNow",
+            "json",
+        ),
+        "get_case": (
+            get_case_tool,
+            GetCaseParams,
+            str,
+            "Get details of a specific customer service case",
+            "json",
         ),
         # Catalog Tools
         "list_catalog_items": (

--- a/tests/test_case_tools.py
+++ b/tests/test_case_tools.py
@@ -1,0 +1,54 @@
+"""Tests for the case management tools."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from servicenow_mcp.auth.auth_manager import AuthManager
+from servicenow_mcp.tools.case_tools import (
+    ListCasesParams,
+    list_cases,
+)
+from servicenow_mcp.utils.config import AuthConfig, AuthType, BasicAuthConfig, ServerConfig
+
+
+class TestCaseTools(unittest.TestCase):
+    """Tests for case management tools."""
+
+    def setUp(self):
+        self.config = ServerConfig(
+            instance_url="https://example.service-now.com",
+            auth=AuthConfig(
+                type=AuthType.BASIC,
+                basic=BasicAuthConfig(username="admin", password="password"),
+            ),
+        )
+        self.auth_manager = AuthManager(self.config.auth)
+        self.auth_manager.get_headers = MagicMock(return_value={"Authorization": "Basic"})
+
+    @patch("servicenow_mcp.tools.case_tools.requests.get")
+    def test_list_cases_success(self, mock_get):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.json.return_value = {
+            "result": [
+                {
+                    "sys_id": "case1",
+                    "number": "CASE001",
+                    "short_description": "Test case",
+                    "state": "open",
+                    "priority": "1",
+                    "assigned_to": {"display_value": "Agent"},
+                }
+            ]
+        }
+        mock_get.return_value = mock_response
+
+        params = ListCasesParams(limit=1)
+        result = list_cases(self.config, self.auth_manager, params)
+        self.assertTrue(result["success"])
+        self.assertEqual(len(result["cases"]), 1)
+        self.assertEqual(result["cases"][0]["number"], "CASE001")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement new case management tools (`create_case`, `update_case`, `list_cases`, `get_case`)
- integrate tools with server utility modules
- document case management tools and add docs link
- extend tool packages to include case tools
- provide example usage for cases in README
- add unit test for `list_cases`

## Testing
- `pytest -q` *(fails: `pytest` not installed)*